### PR TITLE
Fix issue with newer devices requests failing due to case of content-length header

### DIFF
--- a/meross/smartgarage-control.js
+++ b/meross/smartgarage-control.js
@@ -12,35 +12,37 @@ module.exports = function(RED) {
 		this.channel = parseInt(myNode.channel || 0);
 
 		this.on('input', function (msg) {
+			var thisBody = JSON.stringify({
+                                        'header': {
+                                                'messageId': Platform.config.messageid,
+                                                'method': (typeof msg.payload === 'boolean') ?
+                                                                  'SET' :
+                                                                  'GET',
+                                                'from': 'http://' + Platform.ip + '/config',
+                                                'sign': Platform.config.token,
+                                                'namespace': (typeof msg.payload === 'boolean') ?
+                                                                         'Appliance.GarageDoor.State' :
+                                                                         'Appliance.System.All',
+                                                'timestamp': parseInt(Platform.config.timestamp),
+                                                'payloadVersion': 1
+                                        },
+                                        'payload': (typeof msg.payload === 'boolean') ?
+                                         {
+                                                'state': {
+                                                        'open': msg.payload ? 1 : 0,
+                                                        'channel': Platform.channel,
+                                                        'uuid': makeUUID(16)
+                                                }
+                                        } :
+                                        {}
+                                });
 			request.post({
 				url: 'http://' + Platform.ip + '/config',
 				headers: {
-					'Content-Type': 'application/json'
+					'Content-Type': 'application/json',
+					'Content-Length': thisBody.length
 				}, 
-				body: JSON.stringify({
-					'header': {
-						'messageId': Platform.config.messageid,
-						'method': (typeof msg.payload === 'boolean') ?
-								  'SET' :
-								  'GET',
-						'from': 'http://' + Platform.ip + '/config',
-						'sign': Platform.config.token,
-						'namespace': (typeof msg.payload === 'boolean') ?
-									 'Appliance.GarageDoor.State' :
-									 'Appliance.System.All',
-						'timestamp': parseInt(Platform.config.timestamp),
-						'payloadVersion': 1
-					},
-					'payload': (typeof msg.payload === 'boolean') ?
-					 {
-						'state': {
-							'open': msg.payload ? 1 : 0,
-							'channel': Platform.channel,
-							'uuid': makeUUID(16)
-						}
-					} : 
-					{}
-				})
+				body: thisBody
 			}, function(myError, myResponse, myBody) {
 				if(myError) {
 					Platform.warn('There was an Error: ' + myError);

--- a/meross/smartplug-control.js
+++ b/meross/smartplug-control.js
@@ -11,36 +11,38 @@ module.exports = function(RED) {
 		this.ip = myNode.ip;
 
 		this.on('input', function (msg) {
+			var thisBody = JSON.stringify({
+                                        'header': {
+                                                'messageId': Platform.config.messageid,
+                                                'method': (typeof msg.payload === 'boolean') ?
+                                                                  'SET' :
+                                                                  'GET',
+                                                'from': 'http://' + Platform.ip + '/config',
+                                                'sign': Platform.config.token,
+                                                'namespace': (typeof msg.payload === 'boolean') ?
+                                                                         'Appliance.Control.ToggleX' :
+                                                                         (msg.payload.namespace !== undefined) ?
+                                                                         msg.payload.namespace :
+                                                                         'Appliance.System.All',
+                                                'timestamp': parseInt(Platform.config.timestamp),
+                                                'payloadVersion': 1
+                                        },
+                                        'payload': (typeof msg.payload === 'boolean') ?
+                                         {
+                                                'togglex': {
+                                                        'onoff': msg.payload ? 1 : 0,
+                                                        'channel': msg.channel || 0
+                                                }
+                                        } :
+                                        {}
+                                });
 			request.post({
 				url: 'http://' + Platform.ip + '/config',
 				headers: {
-					'Content-Type': 'application/json'
+					'Content-Type': 'application/json',
+					'Content-Length': thisBody.length
 				}, 
-				body: JSON.stringify({
-					'header': {
-						'messageId': Platform.config.messageid,
-						'method': (typeof msg.payload === 'boolean') ?
-								  'SET' :
-								  'GET',
-						'from': 'http://' + Platform.ip + '/config',
-						'sign': Platform.config.token,
-						'namespace': (typeof msg.payload === 'boolean') ?
-									 'Appliance.Control.ToggleX' :
-									 (msg.payload.namespace !== undefined) ?
-									 msg.payload.namespace :
-									 'Appliance.System.All',
-						'timestamp': parseInt(Platform.config.timestamp),
-						'payloadVersion': 1
-					},
-					'payload': (typeof msg.payload === 'boolean') ?
-					 {
-						'togglex': {
-							'onoff': msg.payload ? 1 : 0,
-							'channel': msg.channel || 0
-						}
-					} : 
-					{}
-				})
+				body: thisBody
 			}, function(myError, myResponse, myBody) {
 				if(myError) {
 					Platform.warn('There was an Error: ' + myError);


### PR DESCRIPTION
Linked Issue: https://github.com/dehsgr/node-red-contrib-meross/issues/13

Recently purchased some Meross MSS210-Mini smartplugs
https://www.amazon.co.uk/gp/product/B08D69M19G

These would refuse to work with the current version of the module, with the the connection being dropped immediately after all requests, no response returned.

After a lot of debugging I managed to identify this is due to the new plugs being case sensitive to the content length header. By default the request lib sends 'content-length', when this is altered to 'Content-Length' the device responds. I've altered the code to manually calculate/insert this header with the case as the device prefers it.

I have tested this against my new MSS210-Mini devices and my older big MSS210 with its original firmware and on/off/status functions are working as expected. Interestingly the older device is working regardless of the case of content-length its just these new devices which are picky about the case.