### PR TITLE
Pass IP via msg-object

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Meross Config is a config node to set the token, message id and timestamp for be
 
 ## Meross Smart Plug
 Meross Smart Plug can be used to set smart plugs state and/or poll its current state. For setting smart plugs state to on|off you simply provide a boolean value (true|false). To request its current state you send any non-boolean payload.
-If your smart plug has multiple channels, all channels are triggered by default. You might control specific channels by passing the desired channel index via msg.channel attribute (1...n, 0=all channels).
+If your smart plug has multiple channels, all channels are triggered by default. You might control specific channels by passing the desired channel index via msg.channel attribute (1...n, 0=all channels). You might set the ip by passing the ip adress of your meross device via msg.ip attribute (e.g. '192.168.0.10')
 
 You might query Electricity Information from your Smart Plug (if supported) with the following payload:
 <pre>

--- a/meross/smartgarage-control.js
+++ b/meross/smartgarage-control.js
@@ -10,6 +10,9 @@ module.exports = function(RED) {
 
 		this.config = RED.nodes.getNode(myNode.confignode);
 		this.ip = myNode.ip;
+		if(msg !== undefined && msg.ip !== undefined) {
+			this.ip = msg.ip;
+		}
 		this.channel = parseInt(myNode.channel || 0);
 
 		this.on('input', function (msg) {

--- a/meross/smartplug-control.js
+++ b/meross/smartplug-control.js
@@ -9,7 +9,13 @@ module.exports = function(RED) {
 		var Platform = this;
 
 		this.config = RED.nodes.getNode(myNode.confignode);
-		this.ip = myNode.ip;
+		if(msg !== undefined){
+			this.ip = msg.ip;
+		}
+		
+		if(this.ip === undefined){
+			this.ip = myNode.ip;
+		}
 
 		this.on('input', function (msg) {
 			request.post({

--- a/meross/smartplug-control.js
+++ b/meross/smartplug-control.js
@@ -9,14 +9,11 @@ module.exports = function(RED) {
 		var Platform = this;
 
 		this.config = RED.nodes.getNode(myNode.confignode);
-		if(msg !== undefined){
+		this.ip = myNode.ip;
+		if(msg !== undefined && msg.ip !== undefined) {
 			this.ip = msg.ip;
 		}
 		
-		if(this.ip === undefined){
-			this.ip = myNode.ip;
-		}
-
 		this.on('input', function (msg) {
 			request.post({
 				url: 'http://' + Platform.ip + '/config',


### PR DESCRIPTION
Option to pass the IP-Adress via msg.ip to allow dynamic usage of the smart plug node.
(no more need to create a node for each Meross Smart Plug)

msg.ip wins over Node.IP