### PR TITLE
Send a error instead of a warning

### DIFF
--- a/meross/smartgarage-control.js
+++ b/meross/smartgarage-control.js
@@ -77,7 +77,7 @@ module.exports = function(RED) {
 				}
 			}.init(), function(myError, myResponse, myBody) {
 				if(myError) {
-					Platform.warn('There was an Error: ' + myError);
+					Platform.error('There was an Error: ' + myError, msg);
 				} else {
 					var j = JSON.parse(myResponse.body);
 					try {

--- a/meross/smartplug-control.js
+++ b/meross/smartplug-control.js
@@ -67,7 +67,7 @@ module.exports = function(RED) {
 					return this;
 			}}.init(), function(myError, myResponse, myBody) {
 				if(myError) {
-					Platform.warn('There was an Error: ' + myError);
+					Platform.error('There was an Error: ' + myError, msg);
 				} else {
 					var j = JSON.parse(myResponse.body);
 					try {


### PR DESCRIPTION
Send a error so we can catch it with the catch all error module and do something when a error comes